### PR TITLE
fix(package):change the redbox-react version to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-addons-test-utils": "^0.14.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",
-    "redbox-react": "^1.0.4",
+    "redbox-react": "^1.2.6",
     "redux-devtools": "3.0.0-beta-3",
     "redux-devtools-dock-monitor": "^1.0.0-beta-3",
     "redux-devtools-log-monitor": "^1.0.0-beta-3",


### PR DESCRIPTION
**Update the redbox-react version to 1.2.6 in package.json**
 : to solve the error message ' issue 
>Uncaught Error: imports[1] for react-transform-catch-errors does not look like a React component.